### PR TITLE
FLINK-16024 JDBC Filter Pushdown

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.jdbc.dialect;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.table.JdbcFilterPushdownVisitor;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -142,4 +143,18 @@ public interface JdbcDialect extends Serializable {
      */
     String getSelectFromStatement(
             String tableName, String[] selectFields, String[] conditionFields);
+
+    /**
+     * Get FilterPushdownVisitor that can convert Flink SQL Filter Expression into corresponding SQL
+     * dialect Filter Expression. The resulting string can then be pushdown to SQL data source to
+     * optimize the query.
+     *
+     * <p>You can customize the rendering for your dialect by overriding this method, and extends
+     * from {@link JdbcFilterPushdownVisitor}
+     *
+     * @return {@link JdbcFilterPushdownVisitor}
+     */
+    default JdbcFilterPushdownVisitor getFilterPushdownVisitor() {
+        return new JdbcFilterPushdownVisitor(this::quoteIdentifier);
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/FilterPushdownVisitorResult.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/FilterPushdownVisitorResult.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.table;
+
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+
+import java.util.Optional;
+
+/** The result type of {@link JdbcFilterPushdownVisitor}. */
+public class FilterPushdownVisitorResult {
+    Optional<String> generatedString;
+    SupportsFilterPushDown.Result result;
+
+    public FilterPushdownVisitorResult(
+            Optional<String> generatedString, SupportsFilterPushDown.Result result) {
+        this.generatedString = generatedString;
+        this.result = result;
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcFilterPushdownVisitor.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcFilterPushdownVisitor.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.table;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ExpressionDefaultVisitor;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Visitor to walk a Expression AST. Produces a String that can be used to pushdown the filter,
+ * return Optional.empty() if we cannot pushdown the filter.
+ */
+public class JdbcFilterPushdownVisitor extends ExpressionDefaultVisitor<Optional<String>> {
+    /**
+     * This Map should not be modifed by user code. Semantically it is equivalent to a {@code
+     * Function<ValueLiteralExpression, Optional<String>>}.
+     *
+     * <p>We expose this low-level construct instead of just a function to facilitate customization
+     * of the behavior. User can make a copy of this Map, manipulate the mapping functions to
+     * support different dialects.
+     *
+     * <pre>{@code
+     * Map<Class<? extends LogicalType>, Function<ValueLiteralExpression, Optional<String>>> customMapping =
+     *   new HashMap<>(JdbcFilterPushdownVisitor.defaultLiteralStringifyFunctions);
+     *
+     * customMapping.remove(DateType.class);
+     * customMapping.remove(TimestampType.class);
+     * customMapping.put(ArrayType.class, arrLiteral -> ....);
+     *
+     * new JdbcFilterPushdownVisitor(quoteIdentifier, customMapping);
+     * }</pre>
+     *
+     * <p>Note that the key has to be a class of a type that extends {@link LogicalType}, which
+     * represents the type of Flink SQL literal expression at runtime.
+     */
+    public static final Map<
+                    Class<? extends LogicalType>,
+                    Function<ValueLiteralExpression, Optional<String>>>
+            DEFAULT_LITERAL_TO_STRING_FUNCTIONS;
+
+    private static final Function<ValueLiteralExpression, Optional<String>> toStringRender =
+            litExp -> Optional.of(litExp.toString());
+
+    static {
+        Map<Class<? extends LogicalType>, Function<ValueLiteralExpression, Optional<String>>>
+                localMap = new HashMap<>();
+        localMap.put(BigIntType.class, toStringRender);
+        localMap.put(IntType.class, toStringRender);
+        localMap.put(BooleanType.class, toStringRender);
+        localMap.put(DecimalType.class, toStringRender);
+        localMap.put(DoubleType.class, toStringRender);
+        localMap.put(FloatType.class, toStringRender);
+        localMap.put(SmallIntType.class, toStringRender);
+        localMap.put(VarCharType.class, toStringRender);
+        localMap.put(
+                DateType.class,
+                litExp -> {
+                    DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                    return litExp.getValueAs(LocalDate.class)
+                            .map(d -> String.format("'%s'", d.format(dateFormat)));
+                });
+        localMap.put(
+                TimestampType.class,
+                litExp -> {
+                    LogicalType tpe = litExp.getOutputDataType().getLogicalType();
+                    int secondsPrecision = ((TimestampType) tpe).getPrecision();
+                    String fractionSecPart =
+                            String.join("", Collections.nCopies(secondsPrecision, "S"));
+                    DateTimeFormatter dateTomeFormat =
+                            secondsPrecision > 0
+                                    ? DateTimeFormatter.ofPattern(
+                                            "yyyy-MM-dd HH:mm:ss." + fractionSecPart)
+                                    : DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+                    return litExp.getValueAs(LocalDateTime.class)
+                            .map(d -> String.format("'%s'", d.format(dateTomeFormat)));
+                });
+        DEFAULT_LITERAL_TO_STRING_FUNCTIONS = Collections.unmodifiableMap(localMap);
+    }
+
+    Function<String, String> quoteIdentifierFunction;
+
+    Map<Class<? extends LogicalType>, Function<ValueLiteralExpression, Optional<String>>>
+            literalToStringFunctions;
+
+    /**
+     * Create a JdbcFilterPushdownVisitor.
+     *
+     * @param quoteIdentifierFunction this typically comes from {@link
+     *     org.apache.flink.connector.jdbc.dialect.JdbcDialect#quoteIdentifier}, we use this
+     *     function to wrap column name to make sure it complies to corresponding RDBMS.
+     * @param literalToStringFunctions This is a mapping to convert literal expression to SQL
+     *     string, if not provided, {@value #DEFAULT_LITERAL_TO_STRING_FUNCTIONS} will be used
+     */
+    public JdbcFilterPushdownVisitor(
+            Function<String, String> quoteIdentifierFunction,
+            Map<Class<? extends LogicalType>, Function<ValueLiteralExpression, Optional<String>>>
+                    literalToStringFunctions) {
+        this.quoteIdentifierFunction = quoteIdentifierFunction;
+        this.literalToStringFunctions = literalToStringFunctions;
+    }
+
+    public JdbcFilterPushdownVisitor(Function<String, String> quoteIdentifierFunction) {
+        this(
+                quoteIdentifierFunction,
+                JdbcFilterPushdownVisitor.DEFAULT_LITERAL_TO_STRING_FUNCTIONS);
+    }
+
+    @Override
+    public Optional<String> visit(CallExpression call) {
+        if (BuiltInFunctionDefinitions.EQUALS.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator("=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.LESS_THAN.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator("<", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator("<=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.GREATER_THAN.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator(">", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator(">=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.OR.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator("OR", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.AND.equals(call.getFunctionDefinition())) {
+            return renderBinaryOperator("AND", call.getResolvedChildren());
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> renderBinaryOperator(
+            String operator, List<ResolvedExpression> allOperands) {
+        Optional<String> leftOperandString = allOperands.get(0).accept(this);
+
+        Supplier<Optional<String>> rightOperandString = () -> allOperands.get(1).accept(this);
+
+        return leftOperandString.flatMap(
+                left ->
+                        rightOperandString
+                                .get()
+                                .map(right -> String.format("(%s %s %s)", left, operator, right)));
+    }
+
+    @Override
+    public Optional<String> visit(ValueLiteralExpression litExp) {
+        LogicalType tpe = litExp.getOutputDataType().getLogicalType();
+        Class<?> typeCs = tpe.getClass();
+        if (this.literalToStringFunctions.containsKey(typeCs)) {
+            return this.literalToStringFunctions.get(typeCs).apply(litExp);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<String> visit(FieldReferenceExpression fieldReference) {
+        return Optional.of(this.quoteIdentifierFunction.apply(fieldReference.toString()));
+    }
+
+    @Override
+    protected Optional<String> defaultMethod(Expression expression) {
+        return Optional.empty();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -234,5 +235,146 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
         assertThat(expected)
                 .as("The actual output is not a subset of the expected set.")
                 .containsAll(result);
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+        String partitionedTable = "PARTITIONED_TABLE";
+        tEnv.executeSql(
+                "CREATE TABLE "
+                        + INPUT_TABLE
+                        + "("
+                        + "id BIGINT,"
+                        + "timestamp6_col TIMESTAMP(6),"
+                        + "timestamp9_col TIMESTAMP(9),"
+                        + "time_col TIME,"
+                        + "real_col FLOAT,"
+                        + "double_col DOUBLE,"
+                        + "decimal_col DECIMAL(10, 4)"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + DB_URL
+                        + "',"
+                        + "  'table-name'='"
+                        + INPUT_TABLE
+                        + "'"
+                        + ")");
+
+        // create a partitioned table to ensure no regression
+        tEnv.executeSql(
+                "CREATE TABLE "
+                        + partitionedTable
+                        + "("
+                        + "id BIGINT,"
+                        + "timestamp6_col TIMESTAMP(6),"
+                        + "timestamp9_col TIMESTAMP(9),"
+                        + "time_col TIME,"
+                        + "real_col FLOAT,"
+                        + "double_col DOUBLE,"
+                        + "decimal_col DECIMAL(10, 4)"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + DB_URL
+                        + "',"
+                        + "  'table-name'='"
+                        + INPUT_TABLE
+                        + "',"
+                        + "  'scan.partition.column'='id',\n"
+                        + "  'scan.partition.num'='1',\n"
+                        + "  'scan.partition.lower-bound'='1',\n"
+                        + "  'scan.partition.upper-bound'='1'\n"
+                        + ")");
+
+        // we create a VIEW here to test column remapping, ie. would filter push down work if we
+        // create a view that depends on our source table
+        tEnv.executeSql(
+                String.format(
+                        "CREATE VIEW FAKE_TABLE ("
+                                + "idx, timestamp6_col, timestamp9_col, time_col, real_col, double_col, decimal_col"
+                                + ") as (SELECT * from %s )",
+                        INPUT_TABLE));
+
+        List<String> onlyRow1 =
+                Stream.of(
+                                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 15:35, 1.175E-37, 1.79769E308, 100.1234]")
+                        .collect(Collectors.toList());
+
+        List<String> twoRows =
+                Stream.of(
+                                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 15:35, 1.175E-37, 1.79769E308, 100.1234]",
+                                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, 15:36:01, -1.175E-37, -1.79769E308, 101.1234]")
+                        .collect(Collectors.toList());
+
+        List<String> onlyRow2 =
+                Stream.of(
+                                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, 15:36:01, -1.175E-37, -1.79769E308, 101.1234]")
+                        .collect(Collectors.toList());
+        List<String> noRows = new ArrayList<>();
+
+        // test simple filter
+        assertQueryReturns("SELECT * FROM FAKE_TABLE WHERE idx = 1", onlyRow1);
+        // test TIMESTAMP filter
+        //        assertQueryReturns(
+        //                "SELECT * FROM FAKE_TABLE WHERE timestamp6_col = TO_TIMESTAMP('2020-01-01
+        // 15:35:00.123456')",
+        //                onlyRow1);
+        // test the IN operator
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + "FAKE_TABLE"
+                        + " WHERE 1 = idx AND decimal_col IN (100.1234, 101.1234)",
+                onlyRow1);
+        // test mixing AND and OR operator
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + "FAKE_TABLE"
+                        + " WHERE idx = 1 AND decimal_col = 100.1234 OR decimal_col = 101.1234",
+                twoRows);
+        // test mixing AND/OR with parenthesis, and the swapping the operand of equal expression
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + "FAKE_TABLE"
+                        + " WHERE (2 = idx AND decimal_col = 100.1234) OR decimal_col = 101.1234",
+                onlyRow2);
+
+        // test Greater than, just to make sure we didnt break anything that we cannot pushdown
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + "FAKE_TABLE"
+                        + " WHERE idx = 2 AND decimal_col > 100 OR decimal_col = 101.123",
+                onlyRow2);
+
+        // One more test of parenthesis
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + "FAKE_TABLE"
+                        + " WHERE 2 = idx AND (decimal_col = 100.1234 OR real_col = 101.1234)",
+                noRows);
+
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + partitionedTable
+                        + " WHERE id = 2 AND decimal_col > 100 OR decimal_col = 101.123",
+                noRows);
+
+        assertQueryReturns(
+                "SELECT * FROM "
+                        + partitionedTable
+                        + " WHERE 1 = id AND decimal_col IN (100.1234, 101.1234)",
+                onlyRow1);
+    }
+
+    private List<String> rowIterToList(Iterator<Row> rows) {
+        return CollectionUtil.iteratorToList(rows).stream()
+                .map(Row::toString)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private void assertQueryReturns(String query, List<String> expected) {
+        List<String> actual = rowIterToList(tEnv.executeSql(query).collect());
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcFilterPushdownVisitorTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcFilterPushdownVisitorTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.table;
+
+import org.apache.flink.connector.jdbc.JdbcTestBase;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.derby.DerbyDialectFactory;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.resolver.ExpressionResolver;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.expressions.RexNodeExpression;
+import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
+import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link JdbcFilterPushdownVisitor}. */
+public class JdbcFilterPushdownVisitorTest extends AbstractTestBase {
+
+    private final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    public static final String DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
+    public static final String DB_URL = "jdbc:derby:memory:test";
+    public static final String INPUT_TABLE = "jdbDynamicTableSource";
+
+    public static StreamExecutionEnvironment env;
+    public static TableEnvironment tEnv;
+
+    @Before
+    public void before() throws ClassNotFoundException, SQLException {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+
+        System.setProperty(
+                "derby.stream.error.field", JdbcTestBase.class.getCanonicalName() + ".DEV_NULL");
+        Class.forName(DRIVER_CLASS);
+
+        try (Connection conn = DriverManager.getConnection(DB_URL + ";create=true");
+                Statement statement = conn.createStatement()) {
+            statement.executeUpdate(
+                    "CREATE TABLE "
+                            + INPUT_TABLE
+                            + " ("
+                            + "id BIGINT NOT NULL,"
+                            + "description VARCHAR(200) NOT NULL,"
+                            + "timestamp6_col TIMESTAMP, "
+                            + "timestamp9_col TIMESTAMP, "
+                            + "time_col TIME, "
+                            + "real_col FLOAT(23), "
+                            + // A precision of 23 or less makes FLOAT equivalent to REAL.
+                            "double_col FLOAT(24),"
+                            + // A precision of 24 or greater makes FLOAT equivalent to DOUBLE
+                            // PRECISION.
+                            "decimal_col DECIMAL(10, 4))");
+        }
+        // Create table in Flink, this can be reused across test cases
+        tEnv.executeSql(
+                "CREATE TABLE "
+                        + INPUT_TABLE
+                        + "("
+                        + "id BIGINT,"
+                        + "description VARCHAR(200),"
+                        + "timestamp6_col TIMESTAMP(6),"
+                        + "timestamp9_col TIMESTAMP(9),"
+                        + "time_col TIME,"
+                        + "real_col FLOAT,"
+                        + "double_col DOUBLE,"
+                        + "decimal_col DECIMAL(10, 4)"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + DB_URL
+                        + "',"
+                        + "  'table-name'='"
+                        + INPUT_TABLE
+                        + "'"
+                        + ")");
+    }
+
+    @After
+    public void clearOutputTable() throws Exception {
+        Class.forName(DRIVER_CLASS);
+        try (Connection conn = DriverManager.getConnection(DB_URL);
+                Statement stat = conn.createStatement()) {
+            stat.executeUpdate("DROP TABLE " + INPUT_TABLE);
+        }
+        StreamTestSink.clear();
+    }
+
+    @Test
+    public void testSimpleExpressionPrimitiveType() {
+        ResolvedSchema schema = tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE).getResolvedSchema();
+        List.of(
+                        "id = 6",
+                        "id >= 6",
+                        "id > 6",
+                        "id < 6",
+                        "id <= 5",
+                        "description = 'Halo'",
+                        "real_col > 0.5",
+                        "double_col <= -0.3")
+                .forEach(input -> assertSimpleInputExprEqualsOutExpr(input, schema));
+    }
+
+    @Test
+    public void testComplexExpressionDatetime() {
+        ResolvedSchema schema = tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE).getResolvedSchema();
+        String andExpr = "id = 6 AND timestamp6_col = TIMESTAMP '2022-01-01 07:00:01.333'";
+        assertGeneratedSQLString(
+                andExpr, schema, "((id = 6) AND (timestamp6_col = '2022-01-01 07:00:01.333000'))");
+
+        String orExpr =
+                "timestamp9_col = TIMESTAMP '2022-01-01 07:00:01.333' OR description = 'Halo'";
+        assertGeneratedSQLString(
+                orExpr,
+                schema,
+                "((timestamp9_col = '2022-01-01 07:00:01.333000000') OR (description = 'Halo'))");
+    }
+
+    @Test
+    public void testExpressionWithNull() {
+        ResolvedSchema schema = tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE).getResolvedSchema();
+        String andExpr = "id = NULL AND real_col <= 0.6";
+        assertGeneratedSQLString(andExpr, schema, "((id = null) AND (real_col <= 0.6))");
+
+        String orExpr = "id = 6 OR description = NULL";
+        assertGeneratedSQLString(orExpr, schema, "((id = 6) OR (description = null))");
+    }
+
+    @Test
+    public void testComplexExpressionPrimitiveType() {
+        ResolvedSchema schema = tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE).getResolvedSchema();
+        String andExpr = "id = NULL AND real_col <= 0.6";
+        assertGeneratedSQLString(andExpr, schema, "((id = null) AND (real_col <= 0.6))");
+
+        String orExpr = "id = 6 OR description = NULL";
+        assertGeneratedSQLString(orExpr, schema, "((id = 6) OR (description = null))");
+    }
+
+    private void assertGeneratedSQLString(
+            String inputExpr, ResolvedSchema schema, String expectedOutputExpr) {
+        List<ResolvedExpression> resolved = resolveSQLFilterToExpression(inputExpr, schema);
+        assertEquals(1, resolved.size());
+        JdbcDialect dialect = new DerbyDialectFactory().create();
+        JdbcFilterPushdownVisitor visitor = new JdbcFilterPushdownVisitor(dialect::quoteIdentifier);
+        String generatedString = resolved.get(0).accept(visitor).get();
+        // our visitor always wrap expression
+        assertEquals(expectedOutputExpr, generatedString);
+    }
+
+    private void assertSimpleInputExprEqualsOutExpr(String inputExpr, ResolvedSchema schema) {
+        // our visitor always wrap expression
+        assertGeneratedSQLString(inputExpr, schema, "(" + inputExpr + ")");
+    }
+
+    /**
+     * Resolve a SQL filter expression against a Schema, this method makes use of some
+     * implementation details of Flink.
+     */
+    private List<ResolvedExpression> resolveSQLFilterToExpression(
+            String sqlExp, ResolvedSchema schema) {
+        StreamTableEnvironmentImpl tbImpl = (StreamTableEnvironmentImpl) tEnv;
+
+        FlinkContext ctx = ((PlannerBase) tbImpl.getPlanner()).getFlinkContext();
+        CatalogManager catMan = tbImpl.getCatalogManager();
+        FunctionCatalog funCat = ctx.getFunctionCatalog();
+        RowType sourceType = (RowType) schema.toSourceRowDataType().getLogicalType();
+
+        FlinkTypeFactory typeFactory = new FlinkTypeFactory(classLoader, FlinkTypeSystem.INSTANCE);
+        RexNodeToExpressionConverter converter =
+                new RexNodeToExpressionConverter(
+                        new RexBuilder(typeFactory),
+                        sourceType.getFieldNames().toArray(new String[0]),
+                        funCat,
+                        catMan,
+                        TimeZone.getTimeZone(tEnv.getConfig().getLocalTimeZone()));
+
+        RexNodeExpression rexExp =
+                (RexNodeExpression) tbImpl.getParser().parseSqlExpression(sqlExp, sourceType, null);
+        ResolvedExpression resolvedExp =
+                rexExp.getRexNode()
+                        .accept(converter)
+                        .getOrElse(
+                                () -> {
+                                    throw new IllegalArgumentException(
+                                            "Cannot convert "
+                                                    + rexExp.getRexNode()
+                                                    + " to Expression, this likely "
+                                                    + "means you used some function(s) not "
+                                                    + "supported with this setup.");
+                                });
+        ExpressionResolver resolver =
+                ExpressionResolver.resolverFor(
+                                tEnv.getConfig(),
+                                classLoader,
+                                name -> Optional.empty(),
+                                funCat.asLookup(
+                                        str -> {
+                                            throw new TableException(
+                                                    "We should not need to lookup any expressions at this point");
+                                        }),
+                                catMan.getDataTypeFactory(),
+                                (sqlExpression, inputRowType, outputType) -> {
+                                    throw new TableException(
+                                            "SQL expression parsing is not supported at this location.");
+                                })
+                        .build();
+
+        return resolver.resolve(List.of(resolvedExp));
+    }
+}


### PR DESCRIPTION
Implement Filter Pushdown for JDBC connector source, used pre-existing visitor to parse Flink SQL to JDBC SQL.
Expose the visitor via JDBCDialect to allow customization by user

There seems to be a regression in 1.16.x, TO_TIMESTAMP does not preserve precision correctly, it works in 1.14.x when I last tested

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
